### PR TITLE
✨  Render QRC as SVG

### DIFF
--- a/src/components/qrc-generator/qrc-generator.ts
+++ b/src/components/qrc-generator/qrc-generator.ts
@@ -6,9 +6,6 @@ function main(): void {
   const outputElement = document.getElementById(
     "qrc-output-text"
   ) as HTMLParagraphElement;
-  const canvasElement = document.getElementById(
-    "qrc-canvas"
-  ) as HTMLCanvasElement;
   const imageElement = document.getElementById("qrc-image") as HTMLImageElement;
   const imageLabel = document.getElementById(
     "qrc-image-label"
@@ -17,7 +14,6 @@ function main(): void {
   if (
     inputElement === null ||
     outputElement === null ||
-    canvasElement === null ||
     imageElement === null ||
     imageLabel === null
   ) {
@@ -33,8 +29,9 @@ function main(): void {
     try {
       output = transformUrl(this.value);
       const qrc = QrCode.encodeText(output, QrCode.Ecc.MEDIUM);
-      qrc.drawCanvas(8, 4, canvasElement);
-      imageElement.src = canvasElement.toDataURL();
+      const svg = qrc.toSvgString(4);
+      const svgBlob = new Blob([svg], { type: "image/svg+xml" });
+      imageElement.src = URL.createObjectURL(svgBlob);
       output = "";
       outputElement.classList.add("hidden");
       imageElement.classList.remove("hidden");

--- a/src/pages/qrc-generator.html
+++ b/src/pages/qrc-generator.html
@@ -29,14 +29,12 @@
         </label>
         <textarea name="resource-url-input" id="url-input"
                   class="qrc-generator__input u-margin-bottom-small"
-                  placeholder="enter resource url here" rows="1">
-        </textarea>
+                  placeholder="enter resource url here" rows="1"></textarea>
         <p class="qrc-generator__output hidden" id="qrc-output-text"></p>
         <label class="label-text u-margin-bottom-xsmall hidden" id="qrc-image-label" for="qrc-image">
           generated qrc
         </label>
         <img id="qrc-image" class="qrc-generator__image hidden" src="" alt="generated QR code">
-        <canvas id="qrc-canvas" class="qrc-generator__canvas"></canvas>
       </div>
     </div>
   </section>


### PR DESCRIPTION
After applying this change, the QRC will be rendered as an SVG instead of a PNG.